### PR TITLE
Update regex check for tidal.com

### DIFF
--- a/src/handlers/music-link.handler.ts
+++ b/src/handlers/music-link.handler.ts
@@ -12,7 +12,7 @@ import {
 } from './guards/index.js';
 
 const possibleSongLinkRegex =
-  /(https?:\/\/(?:www\.)?((?:(music\.)?amazon|audiomack|play\.anghami|boomplay|deezer|geo\.music\.apple|play\.napster|pandora|soundcloud|listen\.tidal|((music|www)\.)?youtube|open\.spotify)\.com|youtu\.be|audius\.co|music\.yandex\.ru)\/[^\s)>]+)/;
+  /(https?:\/\/(?:www\.)?((?:(music\.)?amazon|audiomack|play\.anghami|boomplay|deezer|geo\.music\.apple|play\.napster|pandora|soundcloud|((www|listen)\.)?tidal|((music|www)\.)?youtube|open\.spotify)\.com|youtu\.be|audius\.co|music\.yandex\.ru)\/[^\s)>]+)/;
 
 @Injectable()
 export class MusicLinkHandler {


### PR DESCRIPTION
The regex check for tidal links required `listen.tidal.com` links while the desktop and mobile app generate simply `tidal.com` links